### PR TITLE
Support path parameter during upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = ({ env }) => ({
 // file: ./config/plugins.js
 module.exports = ({ env }) => ({
   upload: {
-    provider: 'minio',
+    provider: 'minio-ce',
     providerOptions: {
       accessKey: env('MINIO_ACCESS_KEY', 'Q3AM3UQ867SPQQA43P2F'),
       secretKey: env('MINIO_SECRET_KEY', 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'),

--- a/index.js
+++ b/index.js
@@ -10,14 +10,17 @@ module.exports = {
       accessKey,
       secretKey,
     });
+    const getPath = (file) => {
+      const pathChunk = file.path ? `${file.path}/` : '';
+      const path = folder ? `${folder}/${pathChunk}` : pathChunk;
+
+      return `${path}${file.hash}${file.ext}`;
+    };
     return {
       upload(file) {
         return new Promise((resolve, reject) => {
           // upload file to a bucket
-          let path = `${file.hash}${file.ext}`;
-          if (folder) {
-            path = `${folder}/${path}`
-          }
+          const path = getPath(file);
 
           MINIO.putObject(
             bucket,
@@ -40,10 +43,7 @@ module.exports = {
       delete(file) {
         console.log(file);
         return new Promise((resolve, reject) => {
-          let path = `${file.hash}${file.ext}`;
-          if (folder) {
-            path = `${folder}/${path}`
-          }
+          const path = getPath(file);
 
           MINIO.removeObject(bucket, path, err => {
             if (err) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
       return `${path}${file.hash}${file.ext}`;
     };
     const getDeletePath = (file) => {
-      const hostPart = (useSSL === 'true' ? 'https://' : 'http://') + `${host}/`
+      const hostPart = (useSSL === 'true' ? 'https://' : 'http://') + `${host}/${bucket}/`;
       const path = file.url.replace(hostPart, '');
 
       return path;

--- a/index.js
+++ b/index.js
@@ -10,17 +10,23 @@ module.exports = {
       accessKey,
       secretKey,
     });
-    const getPath = (file) => {
+    const getUploadPath = (file) => {
       const pathChunk = file.path ? `${file.path}/` : '';
       const path = folder ? `${folder}/${pathChunk}` : pathChunk;
 
       return `${path}${file.hash}${file.ext}`;
     };
+    const getDeletePath = (file) => {
+      const hostPart = (useSSL === 'true' ? 'https://' : 'http://') + `${host}/`
+      const path = file.url.replace(hostPart, '');
+
+      return path;
+    };
     return {
       upload(file) {
         return new Promise((resolve, reject) => {
           // upload file to a bucket
-          const path = getPath(file);
+          const path = getUploadPath(file);
 
           MINIO.putObject(
             bucket,
@@ -41,9 +47,8 @@ module.exports = {
         });
       },
       delete(file) {
-        console.log(file);
         return new Promise((resolve, reject) => {
-          const path = getPath(file);
+          const path = getDeletePath(file);
 
           MINIO.removeObject(bucket, path, err => {
             if (err) {


### PR DESCRIPTION
During upload file, "path" parameter can be use like strap-provider-upload-aws and the file can be uploaded to the target path which is created in minio before. And due to there is no path information in the original upload file, a word around the get the path of the file in minio is using the url and trim the host and bucket part. See this function may help other people who want to keep their file other than flat structure.